### PR TITLE
Update dockerfile to work with new baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:7.5.0-alpine
+FROM node:8-alpine
 MAINTAINER Kam Low <hello@sourcey.com>
 
 USER 0
 WORKDIR /opt
 
-RUN apk update \
- && apk add git vim curl wget \
- && rm -rf /var/cache/apk/* \
- && npm install -g spectacle-docs
+RUN apk add --no-cache \
+  nodejs nodejs-npm g++ \
+  python python-dev
+
+RUN npm install --unsafe-perm -g spectacle-docs


### PR DESCRIPTION
Base a new docker file off of node:8-alpine seems to work well with newer sass versions which was an issue with the older alpine images. Adding in python for gyp to work and --unsafe-perm because npm was complaining a lot about it.

Fixing issues with running `sourcey/spectacle` docker file generating below errors:
```TypeError: Cannot read property '$ref' of null
    at replaceRefs (/usr/local/lib/node_modules/spectacle-docs/app/lib/resolve-references.js:169:11)
    at replaceRefs (/usr/local/lib/node_modules/spectacle-docs/app/lib/resolve-references.js:189:5)```